### PR TITLE
feat: animaciones UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Piedra, Papel o Tijera
+
+Mini juego desarrollado con HTML, CSS y JavaScript vanilla. Compite contra la CPU
+hasta alcanzar cinco puntos y mantén tu mejor racha de victorias.
+
+## Estructura
+
+- `index.html`: estructura semántica y accesible del juego.
+- `styles.css`: estilos responsive, con soporte para foco visible y modo oscuro automático.
+- `app.js`: lógica del juego, marcador, persistencia de rachas, sonidos y reinicio.
+
+## Cómo usar
+
+1. Clona el repositorio y abre el archivo `index.html` en tu navegador preferido.
+2. Elige Piedra, Papel o Tijera para jugar cada ronda.
+3. Gana cinco puntos antes que la CPU para incrementar tu racha.
+
+## Pruebas manuales
+
+- Abrir `index.html` en el navegador.
+- Jugar hasta que alguno llegue a 5 puntos y verificar que aparezca el botón **Reiniciar**.
+- Pulsar **Reiniciar** y comprobar que el marcador vuelve a 0.
+- Refrescar la página tras ganar una partida para confirmar que la sección "Mejor racha" conserva el valor más alto.
+- Ganar y perder una ronda para escuchar los sonidos asociados.
+- Activar el botón **Sonido** para silenciar y volver a activar, refrescando la página para validar que la preferencia se conserva.
+
+## Accesibilidad y soporte
+
+- Controles con roles y etiquetas accesibles.
+- Uso de `aria-live` para narrar resultados y marcador.
+- Botones manejables con teclado (Enter/Espacio) y foco visible.
+- Diseño mobile-first adaptable a pantallas mayores y compatible con esquemas de color claros/oscursos.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 Mini juego desarrollado con HTML, CSS y JavaScript vanilla. Compite contra la CPU
 hasta alcanzar cinco puntos y mantén tu mejor racha de victorias.
 
+## Características
+
+- Animaciones suaves en los botones y un temblor al perder que respetan la
+  preferencia del sistema para reducir movimiento.
+- Control de sonido con efectos para victorias/derrotas y botón para silenciar,
+  cuya preferencia persiste en `localStorage`.
+- Marcador accesible con mejor racha almacenada y reinicio al llegar a cinco
+  puntos.
+
 ## Estructura
 
 - `index.html`: estructura semántica y accesible del juego.
@@ -23,6 +32,9 @@ hasta alcanzar cinco puntos y mantén tu mejor racha de victorias.
 - Refrescar la página tras ganar una partida para confirmar que la sección "Mejor racha" conserva el valor más alto.
 - Ganar y perder una ronda para escuchar los sonidos asociados.
 - Activar el botón **Sonido** para silenciar y volver a activar, refrescando la página para validar que la preferencia se conserva.
+- Elegir una jugada y observar la animación; perder una ronda para visualizar el
+  efecto de sacudida (o desactivar las animaciones si el sistema tiene "Reducir
+  movimiento").
 
 ## Accesibilidad y soporte
 

--- a/app.js
+++ b/app.js
@@ -1,0 +1,317 @@
+const WIN_SCORE = 5;
+const STORAGE_KEY = "ppt-best-streak";
+const SOUND_STORAGE_KEY = "ppt-sound-muted";
+
+const state = {
+  playerScore: 0,
+  cpuScore: 0,
+  bestStreak: 0,
+  currentStreak: 0,
+  isGameOver: false,
+  isMuted: false,
+};
+
+const playerScoreEl = document.getElementById("player-score");
+const cpuScoreEl = document.getElementById("cpu-score");
+const bestStreakEl = document.getElementById("best-streak");
+const roundResultEl = document.getElementById("round-result");
+const roundDetailEl = document.getElementById("round-detail");
+const choiceButtons = Array.from(document.querySelectorAll(".choice"));
+const resetButton = document.getElementById("reset-button");
+const resultSection = document.querySelector(".result");
+const muteButton = document.getElementById("mute-button");
+
+let audioContext;
+
+function getCpuChoice() {
+  const options = ["piedra", "papel", "tijera"];
+  const index = Math.floor(Math.random() * options.length);
+  return options[index];
+}
+
+function getRoundResult(playerChoice, cpuChoice) {
+  if (playerChoice === cpuChoice) {
+    return { winner: "draw", message: "Empate" };
+  }
+
+  const winsAgainst = {
+    piedra: "tijera",
+    papel: "piedra",
+    tijera: "papel",
+  };
+
+  if (winsAgainst[playerChoice] === cpuChoice) {
+    return { winner: "player", message: "¡Ganaste la ronda!" };
+  }
+
+  return { winner: "cpu", message: "Perdiste la ronda" };
+}
+
+function updateScoreBoard() {
+  playerScoreEl.textContent = state.playerScore;
+  cpuScoreEl.textContent = state.cpuScore;
+  bestStreakEl.textContent = `Mejor racha: ${state.bestStreak}`;
+}
+
+function renderResult({ winner, message }, playerChoice, cpuChoice) {
+  roundResultEl.textContent = message;
+  const detailMessage = `Tú elegiste ${playerChoice} y la CPU eligió ${cpuChoice}.`;
+  roundDetailEl.textContent = detailMessage;
+
+  resultSection.classList.remove("result--win", "result--lose", "result--draw");
+  if (winner === "player") {
+    resultSection.classList.add("result--win");
+  } else if (winner === "cpu") {
+    resultSection.classList.add("result--lose");
+  } else {
+    resultSection.classList.add("result--draw");
+  }
+}
+
+function triggerChoiceAnimation(button) {
+  button.classList.remove("choice--selected");
+  // Fuerza un reflujo para reiniciar la animación cuando se elige varias veces
+  void button.offsetWidth;
+  button.classList.add("choice--selected");
+}
+
+function triggerLoseAnimation() {
+  resultSection.classList.remove("result--shake");
+  void resultSection.offsetWidth;
+  resultSection.classList.add("result--shake");
+}
+
+function saveBestStreak() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state.bestStreak));
+}
+
+function loadBestStreak() {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) {
+    state.bestStreak = 0;
+    return;
+  }
+
+  try {
+    const value = JSON.parse(stored);
+    if (Number.isInteger(value) && value >= 0) {
+      state.bestStreak = value;
+    }
+  } catch (error) {
+    console.warn("No se pudo leer la mejor racha guardada", error);
+    state.bestStreak = 0;
+  }
+}
+
+function ensureAudioContext() {
+  if (state.isMuted) {
+    return null;
+  }
+
+  if (!audioContext) {
+    const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContextClass) {
+      console.warn("El contexto de audio no es compatible en este navegador.");
+      return null;
+    }
+    audioContext = new AudioContextClass();
+  }
+
+  if (audioContext.state === "suspended") {
+    audioContext.resume();
+  }
+
+  return audioContext;
+}
+
+function playTone({ frequencyStart, frequencyEnd, duration, type }) {
+  const context = ensureAudioContext();
+  if (!context) {
+    return;
+  }
+
+  const oscillator = context.createOscillator();
+  const gainNode = context.createGain();
+  oscillator.type = type;
+  oscillator.frequency.setValueAtTime(frequencyStart, context.currentTime);
+  if (frequencyEnd !== frequencyStart) {
+    oscillator.frequency.linearRampToValueAtTime(
+      frequencyEnd,
+      context.currentTime + duration
+    );
+  }
+
+  gainNode.gain.setValueAtTime(0.0001, context.currentTime);
+  gainNode.gain.exponentialRampToValueAtTime(0.35, context.currentTime + 0.02);
+  gainNode.gain.exponentialRampToValueAtTime(
+    0.0001,
+    context.currentTime + duration + 0.1
+  );
+
+  oscillator.connect(gainNode);
+  gainNode.connect(context.destination);
+
+  oscillator.start(context.currentTime);
+  oscillator.stop(context.currentTime + duration + 0.12);
+}
+
+function playResultSound(winner) {
+  if (state.isMuted) {
+    return;
+  }
+
+  if (winner === "player") {
+    playTone({
+      frequencyStart: 660,
+      frequencyEnd: 990,
+      duration: 0.35,
+      type: "triangle",
+    });
+  } else if (winner === "cpu") {
+    playTone({
+      frequencyStart: 220,
+      frequencyEnd: 130,
+      duration: 0.4,
+      type: "sawtooth",
+    });
+  }
+}
+
+function updateMuteButton() {
+  if (!muteButton) {
+    return;
+  }
+
+  const text = state.isMuted ? "🔇 Sonido desactivado" : "🔊 Sonido activado";
+  const ariaLabel = state.isMuted ? "Sonido desactivado" : "Sonido activado";
+  muteButton.textContent = text;
+  muteButton.setAttribute("aria-label", ariaLabel);
+  muteButton.setAttribute("aria-pressed", String(state.isMuted));
+}
+
+function saveSoundPreference() {
+  localStorage.setItem(SOUND_STORAGE_KEY, JSON.stringify(state.isMuted));
+}
+
+function loadSoundPreference() {
+  const stored = localStorage.getItem(SOUND_STORAGE_KEY);
+  if (!stored) {
+    state.isMuted = false;
+    return;
+  }
+
+  try {
+    const value = JSON.parse(stored);
+    state.isMuted = Boolean(value);
+  } catch (error) {
+    console.warn("No se pudo leer la preferencia de sonido", error);
+    state.isMuted = false;
+  }
+}
+
+function finishMatch(playerWon) {
+  state.isGameOver = true;
+  choiceButtons.forEach((button) => {
+    button.disabled = true;
+  });
+  resetButton.hidden = false;
+
+  if (playerWon) {
+    state.currentStreak += 1;
+    if (state.currentStreak > state.bestStreak) {
+      state.bestStreak = state.currentStreak;
+      saveBestStreak();
+    }
+  } else {
+    state.currentStreak = 0;
+  }
+
+  updateScoreBoard();
+}
+
+function resetGame() {
+  state.playerScore = 0;
+  state.cpuScore = 0;
+  state.isGameOver = false;
+  choiceButtons.forEach((button) => {
+    button.disabled = false;
+  });
+  resetButton.hidden = true;
+
+  roundResultEl.textContent = "Haz tu elección";
+  roundDetailEl.textContent = "";
+  resultSection.classList.remove(
+    "result--win",
+    "result--lose",
+    "result--draw",
+    "result--shake"
+  );
+  updateScoreBoard();
+}
+
+function handlePlayerChoice(event) {
+  if (state.isGameOver) {
+    return;
+  }
+
+  const button = event.currentTarget;
+  triggerChoiceAnimation(button);
+
+  const playerChoice = button.dataset.choice;
+  const cpuChoice = getCpuChoice();
+  const result = getRoundResult(playerChoice, cpuChoice);
+
+  if (result.winner === "player") {
+    state.playerScore += 1;
+  } else if (result.winner === "cpu") {
+    state.cpuScore += 1;
+  }
+
+  renderResult(result, playerChoice, cpuChoice);
+  updateScoreBoard();
+  playResultSound(result.winner);
+
+  if (result.winner === "cpu") {
+    triggerLoseAnimation();
+  }
+
+  if (state.playerScore === WIN_SCORE || state.cpuScore === WIN_SCORE) {
+    const playerWon = state.playerScore === WIN_SCORE;
+    const endMessage = playerWon
+      ? "¡Ganaste la partida!"
+      : "La CPU ganó la partida";
+    roundResultEl.textContent = endMessage;
+    finishMatch(playerWon);
+  }
+}
+
+loadBestStreak();
+loadSoundPreference();
+updateScoreBoard();
+updateMuteButton();
+
+choiceButtons.forEach((button) => {
+  button.addEventListener("click", handlePlayerChoice);
+});
+
+resetButton.addEventListener("click", () => {
+  resetGame();
+});
+
+if (muteButton) {
+  muteButton.addEventListener("click", () => {
+    state.isMuted = !state.isMuted;
+    if (!state.isMuted) {
+      ensureAudioContext();
+    }
+    updateMuteButton();
+    saveSoundPreference();
+  });
+}
+
+document.addEventListener("keydown", (event) => {
+  if ((event.key === "Enter" || event.key === " ") && state.isGameOver) {
+    resetButton.focus();
+  }
+});
+

--- a/app.js
+++ b/app.js
@@ -69,7 +69,9 @@ function renderResult({ winner, message }, playerChoice, cpuChoice) {
 }
 
 function triggerChoiceAnimation(button) {
-  button.classList.remove("choice--selected");
+  choiceButtons.forEach((choice) => {
+    choice.classList.remove("choice--selected");
+  });
   // Fuerza un reflujo para reiniciar la animación cuando se elige varias veces
   void button.offsetWidth;
   button.classList.add("choice--selected");
@@ -235,6 +237,7 @@ function resetGame() {
   state.isGameOver = false;
   choiceButtons.forEach((button) => {
     button.disabled = false;
+    button.classList.remove("choice--selected");
   });
   resetButton.hidden = true;
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Piedra, Papel o Tijera</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="game" aria-labelledby="game-title">
+      <section class="game__panel">
+        <h1 id="game-title">Piedra, Papel o Tijera</h1>
+        <p class="game__description">
+          Elige una opción y compite contra la computadora. ¡Primero en llegar a
+          cinco puntos gana!
+        </p>
+        <div class="scoreboard" aria-live="polite">
+          <div class="scoreboard__row" aria-label="Marcador">
+            <span class="scoreboard__label" id="player-label">Tú</span>
+            <span class="scoreboard__score" id="player-score">0</span>
+            <span class="scoreboard__divider">-</span>
+            <span class="scoreboard__score" id="cpu-score">0</span>
+            <span class="scoreboard__label" id="cpu-label">CPU</span>
+          </div>
+          <p class="scoreboard__best" id="best-streak" aria-live="polite">
+            Mejor racha: 0
+          </p>
+          <button
+            type="button"
+            class="mute"
+            id="mute-button"
+            aria-pressed="false"
+            aria-label="Sonido activado"
+          >
+            🔊 Sonido activado
+          </button>
+        </div>
+        <section class="result" aria-live="polite">
+          <h2 class="result__title" id="round-result">Haz tu elección</h2>
+          <p class="result__detail" id="round-detail"></p>
+        </section>
+        <section class="controls" aria-label="Controles del juego">
+          <div class="controls__buttons" role="group" aria-labelledby="controls-title">
+            <h2 id="controls-title" class="controls__title">Elige tu jugada</h2>
+            <button type="button" class="choice" data-choice="piedra" aria-label="Elegir piedra">
+              Piedra
+            </button>
+            <button type="button" class="choice" data-choice="papel" aria-label="Elegir papel">
+              Papel
+            </button>
+            <button type="button" class="choice" data-choice="tijera" aria-label="Elegir tijera">
+              Tijera
+            </button>
+          </div>
+          <button type="button" class="reset" id="reset-button" hidden>
+            Reiniciar partida
+          </button>
+        </section>
+      </section>
+    </main>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -271,6 +271,20 @@ h1 {
   animation: result-shake 420ms cubic-bezier(0.36, 0.07, 0.19, 0.97);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .choice,
+  .reset,
+  .mute,
+  .result {
+    transition: none;
+  }
+
+  .choice--selected,
+  .result--shake {
+    animation: none;
+  }
+}
+
 @keyframes choice-pop {
   0% {
     transform: scale(1);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,307 @@
+:root {
+  color-scheme: light dark;
+  --bg-color: #f5f5f7;
+  --panel-color: rgba(255, 255, 255, 0.9);
+  --border-color: rgba(32, 33, 36, 0.12);
+  --accent: #1d4ed8;
+  --accent-soft: rgba(29, 78, 216, 0.12);
+  --text-color: #1f2933;
+  --text-muted: #52606d;
+  --success: #059669;
+  --danger: #dc2626;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(160deg, #e0f2fe, #f9fafb);
+  color: var(--text-color);
+}
+
+.game {
+  width: min(420px, 100%);
+  padding: 1.5rem;
+}
+
+.game__panel {
+  background-color: var(--panel-color);
+  border-radius: 1.5rem;
+  padding: 2.5rem 1.75rem;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--border-color);
+}
+
+h1 {
+  margin-top: 0;
+  text-align: center;
+  font-size: 1.8rem;
+  letter-spacing: -0.02em;
+}
+
+.game__description {
+  text-align: center;
+  margin-bottom: 2rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.scoreboard {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.mute {
+  margin-top: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-color: rgba(29, 78, 216, 0.08);
+  color: var(--accent);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease,
+    border-color 150ms ease, background-color 150ms ease;
+}
+
+.mute:hover,
+.mute:focus-visible {
+  border-color: var(--accent);
+  background-color: rgba(29, 78, 216, 0.12);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+  outline: none;
+}
+
+.mute:focus-visible {
+  transform: translateY(-1px);
+}
+
+.mute[aria-pressed="true"] {
+  background-color: rgba(220, 38, 38, 0.08);
+  color: var(--danger);
+}
+
+.mute[aria-pressed="true"]:hover,
+.mute[aria-pressed="true"]:focus-visible {
+  border-color: var(--danger);
+  background-color: rgba(220, 38, 38, 0.12);
+  box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.12);
+}
+.scoreboard__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.scoreboard__label {
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.scoreboard__score {
+  min-width: 2rem;
+}
+
+.scoreboard__divider {
+  color: var(--text-muted);
+}
+
+.scoreboard__best {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.result {
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 1rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  min-height: 80px;
+  display: grid;
+  gap: 0.5rem;
+  justify-items: center;
+  text-align: center;
+  will-change: transform;
+}
+
+.result__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.result__detail {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.controls__title {
+  margin: 0 0 1rem;
+  text-align: center;
+  font-size: 1.1rem;
+  color: var(--text-muted);
+}
+
+.controls__buttons {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.choice,
+.reset {
+  appearance: none;
+  border: 2px solid transparent;
+  background-color: white;
+  color: var(--text-color);
+  padding: 0.85rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease,
+    border-color 150ms ease;
+  will-change: transform;
+}
+
+.choice:hover,
+.choice:focus-visible,
+.reset:hover,
+.reset:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 10px 25px rgba(29, 78, 216, 0.15);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.choice:focus-visible,
+.reset:focus-visible {
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+.choice:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.choice--selected {
+  animation: choice-pop 320ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.reset {
+  margin-top: 1.5rem;
+  width: 100%;
+  background-color: var(--accent);
+  color: white;
+}
+
+.reset[hidden] {
+  display: none;
+}
+
+@media (min-width: 480px) {
+  .controls__buttons {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0f172a;
+    --panel-color: rgba(30, 41, 59, 0.75);
+    --border-color: rgba(148, 163, 184, 0.2);
+    --text-color: #e2e8f0;
+    --text-muted: #cbd5f5;
+  }
+
+  body {
+    background: radial-gradient(circle at top, #1e293b, #0f172a);
+  }
+
+  .choice,
+  .reset {
+    background-color: rgba(15, 23, 42, 0.8);
+  }
+
+  .mute {
+    background-color: rgba(59, 130, 246, 0.18);
+  }
+
+  .mute[aria-pressed="true"] {
+    background-color: rgba(248, 113, 113, 0.18);
+  }
+
+  .result {
+    background-color: rgba(30, 41, 59, 0.7);
+  }
+}
+
+.result--win .result__title {
+  color: var(--success);
+}
+
+.result--lose .result__title {
+  color: var(--danger);
+}
+
+.result--draw .result__title {
+  color: var(--accent);
+}
+
+.result--shake {
+  animation: result-shake 420ms cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}
+
+@keyframes choice-pop {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(0.92);
+  }
+  100% {
+    transform: scale(1.05);
+  }
+}
+
+@keyframes result-shake {
+  10%,
+  90% {
+    transform: translateX(-2px);
+  }
+  20%,
+  80% {
+    transform: translateX(4px);
+  }
+  30%,
+  50%,
+  70% {
+    transform: translateX(-6px);
+  }
+  40%,
+  60% {
+    transform: translateX(6px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
## Resumen
- añadir animación de rebote al presionar los botones de elección para reforzar el feedback visual
- aplicar temblor breve en el panel de resultado cuando la CPU gana una ronda y limpiar el estado al reiniciar
- ajustar estilos con will-change para un renderizado suave de las nuevas transiciones

## Checklist
- [x] Probado manualmente en el navegador
- [x] Animaciones visibles en victoria/derrota
- [x] Código listo para revisión

------
https://chatgpt.com/codex/tasks/task_e_68d48b2d7df88322b81ef8f2fb10a217